### PR TITLE
Feat: 후보자 음성 공약 서비스 페이지 추가

### DIFF
--- a/src/Candidate/CandidatePromise.jsx
+++ b/src/Candidate/CandidatePromise.jsx
@@ -20,33 +20,6 @@ const DetailedPromise = styled.div`
   white-space: pre-wrap;
 `;
 
-// tts service key
-// 086659abbee941cda0bb9d7594bc8581
-
-/*
- * api 사이트
- * https://rapidapi.com/voicerss/api/text-to-speech-1/
- * https://www.voicerss.org/api/
- *
- * 자바스크립트 예시 코드
- * https://codepen.io/SitePoint/pen/JRaLVR
- */
-
-/*
-async function foo() {
-  let url = 'https://api.voicerss.org/?';
-  let key = '086659abbee941cda0bb9d7594bc8581';
-  let queryParams = encodeURIComponent('key') + '=' + key;
-  let str = encodeURIComponent('안녕하세요\n감사합니다.');
-  queryParams += '&' + encodeURIComponent('src') + '=' + str;
-  queryParams += '&' + encodeURIComponent('hl') + '=' + encodeURIComponent('ko-kr');
-  queryParams += '&' + encodeURIComponent('c') + '=' + encodeURIComponent('mp3');
-
-  // let response = await fetch(url + queryParams);
-  console.log(url + queryParams);
-}
-*/
-
 // 후보 공약 페이지
 
 const HuboInfo = ({ p1, p2, p3, p4, p5 }) => {

--- a/src/Candidate/CandidatePromise.jsx
+++ b/src/Candidate/CandidatePromise.jsx
@@ -11,18 +11,6 @@ const Container = styled.div`
   margin: auto;
 `;
 
-/* 
-const PromiseContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  border-style: solid;
-  marign: 20px;
-  height: 30vh;
-  border-radius: 50px;
-`;
-*/
-
 const DetailedPromise = styled.div`
   font-size: 20px;
   text-align: left;
@@ -32,10 +20,36 @@ const DetailedPromise = styled.div`
   white-space: pre-wrap;
 `;
 
+// tts service key
+// 086659abbee941cda0bb9d7594bc8581
+
+/*
+ * api 사이트
+ * https://rapidapi.com/voicerss/api/text-to-speech-1/
+ * https://www.voicerss.org/api/
+ *
+ * 자바스크립트 예시 코드
+ * https://codepen.io/SitePoint/pen/JRaLVR
+ */
+
+/*
+async function foo() {
+  let url = 'https://api.voicerss.org/?';
+  let key = '086659abbee941cda0bb9d7594bc8581';
+  let queryParams = encodeURIComponent('key') + '=' + key;
+  let str = encodeURIComponent('안녕하세요\n감사합니다.');
+  queryParams += '&' + encodeURIComponent('src') + '=' + str;
+  queryParams += '&' + encodeURIComponent('hl') + '=' + encodeURIComponent('ko-kr');
+  queryParams += '&' + encodeURIComponent('c') + '=' + encodeURIComponent('mp3');
+
+  // let response = await fetch(url + queryParams);
+  console.log(url + queryParams);
+}
+*/
+
 // 후보 공약 페이지
 
 const HuboInfo = ({ p1, p2, p3, p4, p5 }) => {
-  console.log(p1);
   return (
     <div>
       <DetailedPromise>{p1}</DetailedPromise>

--- a/src/Candidate/CandidatePromiseVoice.jsx
+++ b/src/Candidate/CandidatePromiseVoice.jsx
@@ -1,0 +1,157 @@
+import React, { useState, useEffect } from 'react';
+import styled from '@emotion/styled';
+import Header from '../Header';
+import Navigator from '../Navigator';
+import PropTypes from 'prop-types';
+
+const Container = styled.div`
+  display: flex;
+  max-width: 1020px;
+  flex-direction: column;
+  margin: auto;
+`;
+
+const PlayButton = styled.div`
+  display: flex;
+  align-items: center;
+  margin: 10px;
+  background-color: rgb(120, 120, 120);
+  border-radius: 15px;
+  height: 90px;
+  color: white;
+  justify-content: center;
+`;
+
+function getURL(str) {
+  let url = 'https://api.voicerss.org/?';
+  let key = '086659abbee941cda0bb9d7594bc8581';
+  let queryParams = encodeURIComponent('key') + '=' + key;
+  let encode_str = encodeURIComponent(str);
+  queryParams += '&' + encodeURIComponent('src') + '=' + encode_str;
+  queryParams += '&' + encodeURIComponent('hl') + '=' + encodeURIComponent('ko-kr');
+  queryParams += '&' + encodeURIComponent('c') + '=' + encodeURIComponent('mp3');
+  return url + queryParams;
+}
+
+const useAudio = (url) => {
+  const [audio] = useState(new Audio(url));
+  const [playing, setPlaying] = useState(false);
+
+  const toggle = () => setPlaying(!playing);
+
+  useEffect(() => {
+    playing ? audio.play() : audio.pause();
+  }, [playing]);
+
+  useEffect(() => {
+    audio.addEventListener('ended', () => setPlaying(false));
+    return () => {
+      audio.removeEventListener('ended', () => setPlaying(false));
+    };
+  }, []);
+
+  return [playing, toggle];
+};
+
+const Player = ({ url }) => {
+  const [playing, toggle] = useAudio(url);
+
+  return (
+    <div>
+      <PlayButton>
+        <button onClick={toggle}>{playing ? 'Pause' : 'Play'}</button>
+      </PlayButton>
+    </div>
+  );
+};
+
+const HuboInfo = ({ p1, p2, p3, p4, p5 }) => {
+  let URL1 = getURL(p1.slice(0, 290));
+  const URL2 = getURL(p2.slice(0, 290));
+  const URL3 = getURL(p3.slice(0, 290));
+  const URL4 = getURL(p4.slice(0, 290));
+  const URL5 = getURL(p5.slice(0, 290));
+
+  return (
+    <div>
+      <p>공약1</p>
+      <Player url={URL1}></Player>
+      <p>공약2</p>
+      <Player url={URL2}></Player>
+      <p>공약3</p>
+      <Player url={URL3}></Player>
+      <p>공약4</p>
+      <Player url={URL4}></Player>
+      <p>공약5</p>
+      <Player url={URL5}></Player>
+    </div>
+  );
+};
+
+function CandidatePromise({ candidates }) {
+  return (
+    <Container>
+      <Header />
+      <Navigator />
+      <div>
+        {candidates && // 여기서 null 인지 체크합니다.
+          candidates.map((candidate) => {
+            return (
+              <HuboInfo
+                key={candidate}
+                p1={candidate.prmmCont1}
+                p2={candidate.prmmCont3}
+                p3={candidate.prmmCont3}
+                p4={candidate.prmmCont4}
+                p5={candidate.prmmCont5}
+              />
+            );
+          })}
+      </div>
+    </Container>
+  );
+}
+
+CandidatePromise.propTypes = {
+  candidates: PropTypes.array,
+};
+
+HuboInfo.propTypes = {
+  p1: PropTypes.string,
+  p2: PropTypes.string,
+  p3: PropTypes.string,
+  p4: PropTypes.string,
+  p5: PropTypes.string,
+};
+
+Player.propTypes = {
+  url: PropTypes.string,
+};
+
+export default CandidatePromise;
+
+// 086659abbee941cda0bb9d7594bc8581
+
+/*
+ * api 사이트
+ * https://rapidapi.com/voicerss/api/text-to-speech-1/
+ * https://www.voicerss.org/api/
+ *
+ * 자바스크립트 예시 코드
+ * https://codepen.io/SitePoint/pen/JRaLVR
+ */
+
+/*
+async function foo() {
+  let url = 'https://api.voicerss.org/?';
+  let key = '086659abbee941cda0bb9d7594bc8581';
+  let queryParams = encodeURIComponent('key') + '=' + key;
+  let str = encodeURIComponent('안녕하세요\n감사합니다.');
+  queryParams += '&' + encodeURIComponent('src') + '=' + str;
+  queryParams += '&' + encodeURIComponent('hl') + '=' + encodeURIComponent('ko-kr');
+  queryParams += '&' + encodeURIComponent('c') + '=' + encodeURIComponent('mp3');
+
+  // let response = await fetch(url + queryParams);
+  console.log(url + queryParams);   // 이 주소로 들어가면 음성이 나온다.
+}
+*/

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Reset from './styles/Reset';
 import HomePage from './pages/Homepage';
 import CandidatePage from './pages/CandidatePage';
+import PromiseVoicePage from './pages/PromiseVoicepage';
 import PollsPage from './pages/PollsPage';
 import PromisePage from './pages/Promisepage';
 
@@ -15,6 +16,7 @@ ReactDOM.render(
       <Route path="/candidate" element={<CandidatePage />} />
       <Route path="/polls" element={<PollsPage />} />
       <Route path="/promise" element={<PromisePage />} />
+      <Route path="/voice" element={<PromiseVoicePage />} />
     </Routes>
   </BrowserRouter>,
   document.getElementById('root'),

--- a/src/pages/PromiseVoicepage.jsx
+++ b/src/pages/PromiseVoicepage.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import usePromise from '../hooks/usePromise';
+import CandidatePromiseVoice from '../Candidate/CandidatePromiseVoice';
+
+function PromiseVoicepage() {
+  const { candidates } = usePromise();
+  return <CandidatePromiseVoice candidates={candidates} />;
+}
+
+export default PromiseVoicepage;


### PR DESCRIPTION
`CandidatePromiseVoice.jsx`

후보자 공약들을 tts api를 사용해서 음성으로 들려주는 페이지를 완성하였습니다.

localhost:3000/voice로 접속하면 확인해 볼 수 있습니다.

